### PR TITLE
Update sync API to fetch real token data

### DIFF
--- a/api/init-sync.ts
+++ b/api/init-sync.ts
@@ -11,11 +11,7 @@ export default async function handler(req, res) {
   const { code, wallet } = req.body
   if (!code || !wallet) return res.status(400).json({ success: false })
 
-  await redis.setex(code, 300, JSON.stringify({
-    wallet,
-    balance: 420,
-    vehicles: ['SupraNFT', 'RX7NFT']
-  }))
+  await redis.setex(code, 300, JSON.stringify({ wallet }))
 
   return res.json({ success: true })
 }

--- a/api/verify-sync.ts
+++ b/api/verify-sync.ts
@@ -1,4 +1,18 @@
 import { Redis } from '@upstash/redis'
+import { ethers } from 'ethers'
+
+const provider = new ethers.JsonRpcProvider(process.env.RPC_URL!)
+const ERC20_ADDRESS = process.env.ERC20_TOKEN_ADDRESS!
+const NFT_ADDRESS = '0xDc2768F656d518F0CdfB27f06D7613C9772B847f'
+
+const ERC20_ABI = [
+  'function balanceOf(address) view returns (uint256)',
+  'function decimals() view returns (uint8)'
+]
+const ERC721_ABI = [
+  'function balanceOf(address) view returns (uint256)',
+  'function tokenOfOwnerByIndex(address,uint256) view returns (uint256)'
+]
 
 const redis = new Redis({
   url: process.env.UPSTASH_REDIS_REST_URL!,
@@ -17,11 +31,29 @@ export default async function handler(req, res) {
   await redis.del(code) // one-time use
 
   const data = typeof raw === 'string' ? JSON.parse(raw) : raw
+  const wallet = data.wallet
 
-  return res.json({
-    success: true,
-    wallet: data.wallet,
-    balance: data.balance,
-    vehicles: data.vehicles
-  })
+  try {
+    const erc20 = new ethers.Contract(ERC20_ADDRESS, ERC20_ABI, provider)
+    const decimals: number = await erc20.decimals()
+    const balBig = await erc20.balanceOf(wallet)
+    const erc20Balance = Number(balBig) / 10 ** decimals
+
+    const nft = new ethers.Contract(NFT_ADDRESS, ERC721_ABI, provider)
+    const nftBalance: bigint = await nft.balanceOf(wallet)
+    const nfts: string[] = []
+    for (let i = 0n; i < nftBalance; i++) {
+      try {
+        const id: bigint = await nft.tokenOfOwnerByIndex(wallet, i)
+        nfts.push(id.toString())
+      } catch {
+        break
+      }
+    }
+
+    return res.json({ success: true, wallet, erc20Balance, nfts })
+  } catch (err) {
+    console.error(err)
+    return res.status(500).json({ success: false })
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.7.0"
+    "react-router-dom": "^7.7.0",
+    "ethers": "^6.10.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION
## Summary
- fetch ERC20 and NFT ownership details
- persist only wallet address during sync init
- add ethers library

## Testing
- `npm run lint` *(fails: package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688b2d4d32b08331b2f6c5101ac9c5bf