### PR TITLE
Rebrand front-end to Midnight+

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/midnight.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Web3 Car Racing Marketplace</title>
+    <title>Midnight+ Marketplace</title>
+    <meta
+      name="description"
+      content="Midnight+ Marketplace for digital racing assets"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/public/midnight.svg
+++ b/public/midnight.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="#0f172a" />
+  <path d="M32 20v24M20 32h24" stroke="#38bdf8" stroke-width="8" stroke-linecap="round" />
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ function App() {
   return (
     <GameIntegrationProvider>
       <Router>
-        <div className="min-h-screen bg-gray-900">
+        <div className="min-h-screen bg-midnight-900">
           <Header user={user} setUser={setUser} />
           <Routes>
             <Route path="/" element={<Marketplace user={user} setUser={setUser} />} />

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -10,8 +10,8 @@ const Analytics: React.FC = () => {
   ];
 
   const categoryData = [
-    { category: 'Cars', volume: '1,245 ETH', count: 3421, icon: Car, color: 'bg-blue-500' },
-    { category: 'Modifications', volume: '892 ETH', count: 5643, icon: Zap, color: 'bg-yellow-500' },
+    { category: 'Cars', volume: '1,245 ETH', count: 3421, icon: Car, color: 'bg-neon-500' },
+    { category: 'Modifications', volume: '892 ETH', count: 5643, icon: Zap, color: 'bg-purple-500' },
     { category: 'Property', volume: '710 ETH', count: 876, icon: Home, color: 'bg-green-500' }
   ];
 
@@ -22,12 +22,12 @@ const Analytics: React.FC = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-gray-900">
+    <div className="min-h-screen bg-midnight-900">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-white mb-2">Market Analytics</h1>
-          <p className="text-gray-400">Real-time insights into the RaceVault marketplace</p>
+          <p className="text-gray-400">Real-time insights into the Midnight+ marketplace</p>
         </div>
 
         {/* Market Stats */}
@@ -35,9 +35,9 @@ const Analytics: React.FC = () => {
           {marketStats.map((stat, index) => {
             const Icon = stat.icon;
             return (
-              <div key={index} className="bg-gray-800 border border-gray-700 rounded-xl p-6">
+              <div key={index} className="bg-midnight-800 border border-midnight-700 rounded-xl p-6">
                 <div className="flex items-center justify-between mb-4">
-                  <Icon className="h-8 w-8 text-blue-400" />
+                  <Icon className="h-8 w-8 text-neon-400" />
                   <span className="text-green-400 text-sm font-semibold">{stat.change}</span>
                 </div>
                 <p className="text-gray-400 text-sm">{stat.label}</p>
@@ -49,13 +49,13 @@ const Analytics: React.FC = () => {
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
           {/* Category Performance */}
-          <div className="bg-gray-800 border border-gray-700 rounded-xl p-6">
+          <div className="bg-midnight-800 border border-midnight-700 rounded-xl p-6">
             <h3 className="text-xl font-bold text-white mb-6">Category Performance</h3>
             <div className="space-y-4">
               {categoryData.map((category, index) => {
                 const Icon = category.icon;
                 return (
-                  <div key={index} className="flex items-center justify-between p-4 bg-gray-750 rounded-lg">
+                  <div key={index} className="flex items-center justify-between p-4 bg-midnight-700 rounded-lg">
                     <div className="flex items-center space-x-3">
                       <div className={`p-2 rounded-lg ${category.color}/20`}>
                         <Icon className={`h-5 w-5 text-${category.color.split('-')[1]}-400`} />
@@ -67,7 +67,7 @@ const Analytics: React.FC = () => {
                     </div>
                     <div className="text-right">
                       <p className="text-white font-semibold">{category.volume}</p>
-                      <div className="w-20 bg-gray-700 rounded-full h-2 mt-1">
+                      <div className="w-20 bg-midnight-600 rounded-full h-2 mt-1">
                         <div 
                           className={`${category.color} h-2 rounded-full transition-all duration-300`}
                           style={{ width: `${(index + 1) * 30}%` }}
@@ -81,12 +81,12 @@ const Analytics: React.FC = () => {
           </div>
 
           {/* Top Sales */}
-          <div className="bg-gray-800 border border-gray-700 rounded-xl p-6">
+          <div className="bg-midnight-800 border border-midnight-700 rounded-xl p-6">
             <h3 className="text-xl font-bold text-white mb-6">Top Sales (24h)</h3>
             <div className="space-y-4">
               {topSales.map((sale, index) => (
-                <div key={index} className="flex items-center space-x-4 p-4 bg-gray-750 rounded-lg hover:bg-gray-700 transition-colors duration-200">
-                  <div className="flex items-center justify-center w-8 h-8 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full text-white font-bold text-sm">
+                <div key={index} className="flex items-center space-x-4 p-4 bg-midnight-700 rounded-lg hover:bg-midnight-600 transition-colors duration-200">
+                  <div className="flex items-center justify-center w-8 h-8 bg-gradient-to-r from-neon-500 to-neon-400 rounded-full text-white font-bold text-sm">
                     #{index + 1}
                   </div>
                   <img
@@ -96,7 +96,7 @@ const Analytics: React.FC = () => {
                   />
                   <div className="flex-1">
                     <p className="text-white font-semibold">{sale.name}</p>
-                    <p className="text-blue-400 font-bold">{sale.price}</p>
+                    <p className="text-neon-400 font-bold">{sale.price}</p>
                   </div>
                   <TrendingUp className="h-5 w-5 text-green-400" />
                 </div>
@@ -106,9 +106,9 @@ const Analytics: React.FC = () => {
         </div>
 
         {/* Market Trends Chart Placeholder */}
-        <div className="mt-8 bg-gray-800 border border-gray-700 rounded-xl p-6">
+        <div className="mt-8 bg-midnight-800 border border-midnight-700 rounded-xl p-6">
           <h3 className="text-xl font-bold text-white mb-6">Market Trends</h3>
-          <div className="h-64 bg-gray-750 rounded-lg flex items-center justify-center">
+          <div className="h-64 bg-midnight-700 rounded-lg flex items-center justify-center">
             <div className="text-center">
               <TrendingUp className="h-12 w-12 text-gray-600 mx-auto mb-4" />
               <p className="text-gray-400">Market trends chart will be implemented with real data</p>

--- a/src/components/AssetDetail.tsx
+++ b/src/components/AssetDetail.tsx
@@ -15,7 +15,7 @@ const AssetDetail: React.FC<AssetDetailProps> = ({ asset, user, onBack, onBuy })
     switch (rarity) {
       case 'Legendary': return 'from-yellow-400 to-orange-500';
       case 'Epic': return 'from-purple-400 to-pink-500';
-      case 'Rare': return 'from-blue-400 to-cyan-500';
+      case 'Rare': return 'from-neon-400 to-neon-500';
       default: return 'from-gray-400 to-gray-500';
     }
   };
@@ -31,7 +31,7 @@ const AssetDetail: React.FC<AssetDetailProps> = ({ asset, user, onBack, onBuy })
   };
 
   return (
-    <div className="min-h-screen bg-gray-900">
+    <div className="min-h-screen bg-midnight-900">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Back Button */}
         <button
@@ -65,11 +65,11 @@ const AssetDetail: React.FC<AssetDetailProps> = ({ asset, user, onBack, onBuy })
             </div>
 
             {/* Price */}
-            <div className="bg-gray-800 border border-gray-700 rounded-xl p-6">
+            <div className="bg-midnight-800 border border-midnight-700 rounded-xl p-6">
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-gray-400 text-sm">Current Price</p>
-                  <p className="text-3xl font-bold text-blue-400">{formatPrice(asset.price)}</p>
+                  <p className="text-3xl font-bold text-neon-400">{formatPrice(asset.price)}</p>
                 </div>
                 <div className="text-right">
                   <p className="text-gray-400 text-sm">Category</p>
@@ -80,7 +80,7 @@ const AssetDetail: React.FC<AssetDetailProps> = ({ asset, user, onBack, onBuy })
 
             {/* Specifications */}
             {(asset.category === 'car' || asset.category === 'modification') && (
-              <div className="bg-gray-800 border border-gray-700 rounded-xl p-6">
+              <div className="bg-midnight-800 border border-midnight-700 rounded-xl p-6">
                 <h3 className="text-xl font-bold text-white mb-4">Specifications</h3>
                 <div className="grid grid-cols-2 gap-4">
                   {Object.entries(asset.specs).map(([stat, value]) => (
@@ -92,9 +92,9 @@ const AssetDetail: React.FC<AssetDetailProps> = ({ asset, user, onBack, onBuy })
                         </div>
                         <span className="text-white font-semibold">{value}</span>
                       </div>
-                      <div className="w-full bg-gray-700 rounded-full h-2">
+                      <div className="w-full bg-midnight-700 rounded-full h-2">
                         <div
-                          className="bg-gradient-to-r from-blue-500 to-purple-500 h-2 rounded-full transition-all duration-300"
+                          className="bg-gradient-to-r from-neon-500 to-neon-400 h-2 rounded-full transition-all duration-300"
                           style={{ width: `${value}%` }}
                         />
                       </div>
@@ -105,17 +105,17 @@ const AssetDetail: React.FC<AssetDetailProps> = ({ asset, user, onBack, onBuy })
             )}
 
             {/* Transaction History */}
-            <div className="bg-gray-800 border border-gray-700 rounded-xl p-6">
+            <div className="bg-midnight-800 border border-midnight-700 rounded-xl p-6">
               <h3 className="text-xl font-bold text-white mb-4">Transaction History</h3>
               <div className="space-y-3">
-                <div className="flex items-center justify-between py-2 border-b border-gray-700">
+                <div className="flex items-center justify-between py-2 border-b border-midnight-700">
                   <div className="flex items-center space-x-2">
                     <Clock className="h-4 w-4 text-gray-400" />
                     <span className="text-gray-400">Listed for sale</span>
                   </div>
                   <span className="text-white">2 days ago</span>
                 </div>
-                <div className="flex items-center justify-between py-2 border-b border-gray-700">
+                <div className="flex items-center justify-between py-2 border-b border-midnight-700">
                   <div className="flex items-center space-x-2">
                     <Award className="h-4 w-4 text-green-400" />
                     <span className="text-gray-400">Minted</span>
@@ -131,7 +131,7 @@ const AssetDetail: React.FC<AssetDetailProps> = ({ asset, user, onBack, onBuy })
                 <button
                   onClick={() => onBuy(asset)}
                   disabled={!user || user.balance < asset.price}
-                  className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 disabled:from-gray-600 disabled:to-gray-700 disabled:cursor-not-allowed text-white font-semibold py-4 rounded-xl transition-all duration-200 transform hover:scale-105"
+                  className="w-full bg-gradient-to-r from-neon-500 to-neon-400 hover:from-neon-600 hover:to-neon-500 disabled:from-midnight-600 disabled:to-midnight-700 disabled:cursor-not-allowed text-white font-semibold py-4 rounded-xl transition-all duration-200 transform hover:scale-105"
                 >
                   {!user ? 'Connect Wallet to Buy' : 
                    user.balance < asset.price ? 'Insufficient Balance' : 
@@ -139,7 +139,7 @@ const AssetDetail: React.FC<AssetDetailProps> = ({ asset, user, onBack, onBuy })
                 </button>
               )}
               
-              <button className="w-full bg-gray-700 hover:bg-gray-600 text-white font-semibold py-3 rounded-xl transition-colors duration-200">
+              <button className="w-full bg-midnight-700 hover:bg-midnight-600 text-white font-semibold py-3 rounded-xl transition-colors duration-200">
                 Make Offer
               </button>
             </div>

--- a/src/components/CarCard.tsx
+++ b/src/components/CarCard.tsx
@@ -15,7 +15,7 @@ const CarCard: React.FC<CarCardProps> = ({ car, onBuy, onView, showBuyButton = t
     switch (rarity) {
       case 'Legendary': return 'from-yellow-400 to-orange-500';
       case 'Epic': return 'from-purple-400 to-pink-500';
-      case 'Rare': return 'from-blue-400 to-cyan-500';
+      case 'Rare': return 'from-neon-400 to-neon-500';
       default: return 'from-gray-400 to-gray-500';
     }
   };
@@ -30,7 +30,7 @@ const CarCard: React.FC<CarCardProps> = ({ car, onBuy, onView, showBuyButton = t
   };
 
   return (
-    <div className="bg-gray-800 rounded-xl overflow-hidden border border-gray-700 hover:border-blue-500 transition-all duration-300 transform hover:scale-105 hover:shadow-2xl">
+    <div className="bg-midnight-800 rounded-xl overflow-hidden border border-midnight-700 hover:border-neon-500 transition-all duration-300 transform hover:scale-105 hover:shadow-2xl">
       {/* Image */}
       <div className="relative">
         <img
@@ -52,7 +52,7 @@ const CarCard: React.FC<CarCardProps> = ({ car, onBuy, onView, showBuyButton = t
         {car.vehicleCode && (
           <div className="mb-2">
             <p className="text-xs text-gray-400">VEHICLE CODE</p>
-            <p className="text-sm font-mono text-cyan-400 bg-gray-900 px-2 py-1 rounded">{car.vehicleCode}</p>
+            <p className="text-sm font-mono text-cyan-400 bg-midnight-900 px-2 py-1 rounded">{car.vehicleCode}</p>
           </div>
         )}
         <p className="text-gray-400 text-sm mb-3 line-clamp-2">{car.description}</p>
@@ -61,7 +61,7 @@ const CarCard: React.FC<CarCardProps> = ({ car, onBuy, onView, showBuyButton = t
         {(car.category === 'car' || car.category === 'modification') && (
           <div className="grid grid-cols-2 gap-2 mb-4">
             <div className="flex items-center space-x-1 text-sm">
-              <Gauge className="h-3 w-3 text-blue-400" />
+              <Gauge className="h-3 w-3 text-neon-400" />
               <span className="text-gray-400">Speed:</span>
               <span className="text-white">{car.specs.speed}</span>
             </div>
@@ -75,20 +75,20 @@ const CarCard: React.FC<CarCardProps> = ({ car, onBuy, onView, showBuyButton = t
 
         {/* Price and Actions */}
         <div className="flex items-center justify-between">
-          <div className="text-lg font-bold text-blue-400">
+          <div className="text-lg font-bold text-neon-400">
             {formatPrice(car.price, 'UNT')}
           </div>
           <div className="flex space-x-2">
             <button
               onClick={() => onView?.(car)}
-              className="px-3 py-1 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded-lg transition-colors duration-200"
+              className="px-3 py-1 bg-midnight-700 hover:bg-midnight-600 text-white text-sm rounded-lg transition-colors duration-200"
             >
               View
             </button>
             {showBuyButton && car.forSale && (
               <button
                 onClick={() => onBuy?.(car)}
-                className="px-3 py-1 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white text-sm rounded-lg transition-all duration-200"
+                className="px-3 py-1 bg-gradient-to-r from-neon-500 to-neon-400 hover:from-neon-600 hover:to-neon-500 text-white text-sm rounded-lg transition-all duration-200"
               >
                 Buy Now
               </button>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -36,7 +36,7 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
   const fetchPlayerVehicles = useCallback(async (playerId: string) => {
     setIsLoading(true);
     try {
-      const apiUrl = import.meta.env.VITE_APP_API_URL || "https://racevault.onrender.com";
+      const apiUrl = import.meta.env.VITE_APP_API_URL || "https://midnightplus.example";
       const response = await fetch(`${apiUrl}/api/player-vehicles/${playerId}`);
       const data = await response.json();
       if (data.success) {
@@ -131,7 +131,7 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
         try {
           const apiUrl =
             import.meta.env.VITE_APP_API_URL ||
-            "https://racevault.onrender.com";
+            "https://midnightplus.example";
           const response = await fetch(`${apiUrl}/api/purchase-vehicle`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -170,7 +170,7 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
 
   if (!user) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center">
+      <div className="min-h-screen bg-midnight-900 flex items-center justify-center">
         <div className="text-center">
           <Wallet className="h-16 w-16 text-gray-600 mx-auto mb-4" />
           <h2 className="text-2xl font-bold text-white mb-2">
@@ -191,7 +191,7 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
   }, {});
 
   return (
-    <div className="min-h-screen bg-gray-900">
+    <div className="min-h-screen bg-midnight-900">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-white mb-2">Dashboard</h1>
@@ -203,7 +203,7 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
         <div className="mb-6">
           <button
             onClick={() => setShowGamePanel(!showGamePanel)}
-            className="bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white px-6 py-2 rounded-lg font-semibold transition-all duration-200 transform hover:scale-105"
+            className="bg-gradient-to-r from-neon-500 to-neon-400 hover:from-neon-600 hover:to-neon-500 text-white px-6 py-2 rounded-lg font-semibold transition-all duration-200 transform hover:scale-105"
           >
             {showGamePanel ? "Hide" : "Show"} Game Integration
           </button>
@@ -217,11 +217,11 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
         )}
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-          <div className="bg-gray-800 border border-gray-700 rounded-xl p-6">
+          <div className="bg-midnight-800 border border-midnight-700 rounded-xl p-6">
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-gray-400 text-sm">Wallet Balance</p>
-                <p className="text-2xl font-bold text-blue-400">
+                <p className="text-2xl font-bold text-neon-400">
                   {Number(user.balance).toLocaleString(undefined, {
                     minimumFractionDigits: 5,
                     maximumFractionDigits: 5,
@@ -229,26 +229,26 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
                   ETH
                 </p>
               </div>
-              <Wallet className="h-8 w-8 text-blue-400" />
+              <Wallet className="h-8 w-8 text-neon-400" />
             </div>
           </div>
 
-          <div className="bg-gray-800 border border-gray-700 rounded-xl p-6">
+          <div className="bg-midnight-800 border border-midnight-700 rounded-xl p-6">
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-gray-400 text-sm">Token Balance</p>
-                <p className="text-2xl font-bold text-purple-400">
+                <p className="text-2xl font-bold text-neon-400">
                   {tokenBalance.toLocaleString(undefined, {
                     minimumFractionDigits: 2,
                     maximumFractionDigits: 2,
                   })}
                 </p>
               </div>
-              <Coins className="h-8 w-8 text-purple-400" />
+              <Coins className="h-8 w-8 text-neon-400" />
             </div>
           </div>
 
-          <div className="bg-gray-800 border border-gray-700 rounded-xl p-6">
+          <div className="bg-midnight-800 border border-midnight-700 rounded-xl p-6">
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-gray-400 text-sm">Portfolio Value</p>
@@ -260,13 +260,13 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
             </div>
           </div>
 
-          <div className="bg-gray-800 border border-gray-700 rounded-xl p-6">
+          <div className="bg-midnight-800 border border-midnight-700 rounded-xl p-6">
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-gray-400 text-sm">Total Assets</p>
-                <p className="text-2xl font-bold text-purple-400">{ownedVehicles.length}</p>
+                <p className="text-2xl font-bold text-neon-400">{ownedVehicles.length}</p>
               </div>
-              <Award className="h-8 w-8 text-purple-400" />
+              <Award className="h-8 w-8 text-neon-400" />
             </div>
           </div>
         </div>
@@ -277,8 +277,8 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
             onClick={() => setActiveTab("portfolio")}
             className={`px-6 py-3 rounded-lg font-semibold transition-colors duration-200 ${
               activeTab === "portfolio"
-                ? "bg-blue-600 text-white"
-                : "bg-gray-800 text-gray-400 hover:text-white"
+                ? "bg-neon-500 text-white"
+                : "bg-midnight-800 text-gray-400 hover:text-white"
             }`}
           >
             My Portfolio
@@ -287,8 +287,8 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
             onClick={() => setActiveTab("transactions")}
             className={`px-6 py-3 rounded-lg font-semibold transition-colors duration-200 ${
               activeTab === "transactions"
-                ? "bg-blue-600 text-white"
-                : "bg-gray-800 text-gray-400 hover:text-white"
+                ? "bg-neon-500 text-white"
+                : "bg-midnight-800 text-gray-400 hover:text-white"
             }`}
           >
             Transaction History
@@ -299,21 +299,21 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
           <div>
             {/* Category Breakdown */}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-              <div className="bg-gray-800 border border-gray-700 rounded-xl p-6 text-center">
-                <Car className="h-8 w-8 text-blue-400 mx-auto mb-2" />
+              <div className="bg-midnight-800 border border-midnight-700 rounded-xl p-6 text-center">
+                <Car className="h-8 w-8 text-neon-400 mx-auto mb-2" />
                 <p className="text-2xl font-bold text-white">
                   {categoryStats.car || 0}
                 </p>
                 <p className="text-gray-400">Cars</p>
               </div>
-              <div className="bg-gray-800 border border-gray-700 rounded-xl p-6 text-center">
+              <div className="bg-midnight-800 border border-midnight-700 rounded-xl p-6 text-center">
                 <Zap className="h-8 w-8 text-yellow-400 mx-auto mb-2" />
                 <p className="text-2xl font-bold text-white">
                   {categoryStats.modification || 0}
                 </p>
                 <p className="text-gray-400">Modifications</p>
               </div>
-              <div className="bg-gray-800 border border-gray-700 rounded-xl p-6 text-center">
+              <div className="bg-midnight-800 border border-midnight-700 rounded-xl p-6 text-center">
                 <Home className="h-8 w-8 text-green-400 mx-auto mb-2" />
                 <p className="text-2xl font-bold text-white">
                   {categoryStats.property || 0}
@@ -325,7 +325,7 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
             {/* Owned Assets */}
                         {isLoading ? (
                           <div className="text-center py-16">
-                            <Loader2 className="h-16 w-16 text-blue-500 mx-auto mb-4 animate-spin" />
+                            <Loader2 className="h-16 w-16 text-neon-500 mx-auto mb-4 animate-spin" />
                             <h3 className="text-xl font-semibold text-gray-400">Loading Your Vehicles...</h3>
                           </div>
                         ) : ownedVehicles.length > 0 ? (
@@ -345,24 +345,24 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
         )}
 
         {activeTab === "transactions" && (
-          <div className="bg-gray-800 border border-gray-700 rounded-xl overflow-hidden">
-            <div className="p-6 border-b border-gray-700">
+          <div className="bg-midnight-800 border border-midnight-700 rounded-xl overflow-hidden">
+            <div className="p-6 border-b border-midnight-700">
               <h3 className="text-xl font-bold text-white">
                 Recent Transactions
               </h3>
             </div>
-            <div className="divide-y divide-gray-700">
+            <div className="divide-y divide-midnight-700">
               {mockTransactions.map((transaction) => (
                 <div
                   key={transaction.id}
-                  className="p-6 hover:bg-gray-750 transition-colors duration-200"
+                  className="p-6 hover:bg-midnight-700 transition-colors duration-200"
                 >
                   <div className="flex items-center justify-between">
                     <div className="flex items-center space-x-4">
                       <div
                         className={`p-2 rounded-full ${
                           transaction.type === "purchase"
-                            ? "bg-blue-500/20 text-blue-400"
+                            ? "bg-neon-500/20 text-neon-400"
                             : transaction.type === "sale"
                             ? "bg-green-500/20 text-green-400"
                             : "bg-purple-500/20 text-purple-400"

--- a/src/components/GameIntegrationPanel.tsx
+++ b/src/components/GameIntegrationPanel.tsx
@@ -79,10 +79,10 @@ const GameIntegrationPanel: React.FC<GameIntegrationPanelProps> = ({ user, token
   };
 
   return (
-    <div className="bg-gray-800 border border-gray-700 rounded-xl p-6">
+    <div className="bg-midnight-800 border border-midnight-700 rounded-xl p-6">
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center space-x-3">
-          <div className="bg-gradient-to-r from-purple-500 to-pink-500 p-2 rounded-lg">
+          <div className="bg-gradient-to-r from-neon-500 to-neon-400 p-2 rounded-lg">
             <Gamepad2 className="h-6 w-6 text-white" />
           </div>
           <div>
@@ -94,7 +94,7 @@ const GameIntegrationPanel: React.FC<GameIntegrationPanelProps> = ({ user, token
       </div>
 
       {/* Connection Status */}
-      <div className="bg-gray-750 rounded-lg p-4 mb-6">
+      <div className="bg-midnight-700 rounded-lg p-4 mb-6">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center space-x-3">
             <div className={getStatusColor()}>
@@ -126,7 +126,7 @@ const GameIntegrationPanel: React.FC<GameIntegrationPanelProps> = ({ user, token
             className={`flex-1 py-2 px-4 rounded-lg font-semibold transition-colors duration-200 ${
               isGameConnected
                 ? 'bg-red-600 hover:bg-red-700 text-white'
-                : 'bg-blue-600 hover:bg-blue-700 text-white'
+                : 'bg-neon-500 hover:bg-neon-600 text-white'
             } disabled:opacity-50 disabled:cursor-not-allowed`}
           >
             {isGameConnected ? 'Disconnect' : 'Connect Game'}
@@ -137,13 +137,13 @@ const GameIntegrationPanel: React.FC<GameIntegrationPanelProps> = ({ user, token
               <button
                 onClick={handleSync}
                 disabled={gameStatus === 'syncing'}
-                className="bg-purple-600 hover:bg-purple-700 text-white py-2 px-4 rounded-lg font-semibold transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="bg-neon-500 hover:bg-neon-600 text-white py-2 px-4 rounded-lg font-semibold transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <RefreshCw className={`h-4 w-4 ${gameStatus === 'syncing' ? 'animate-spin' : ''}`} />
               </button>
               <button
                 onClick={handlePairing}
-                className="bg-indigo-600 hover:bg-indigo-700 text-white py-2 px-4 rounded-lg font-semibold transition-colors duration-200"
+                className="bg-neon-600 hover:bg-neon-500 text-white py-2 px-4 rounded-lg font-semibold transition-colors duration-200"
               >
                 Pair with Game
               </button>
@@ -153,9 +153,9 @@ const GameIntegrationPanel: React.FC<GameIntegrationPanelProps> = ({ user, token
       </div>
 
       {isGameConnected && syncCode && (
-        <div className="bg-gray-750 rounded-lg p-4 mb-6 text-center">
+        <div className="bg-midnight-700 rounded-lg p-4 mb-6 text-center">
           <p className="text-gray-300 mb-2">Type this command in BeamMP chat to pair:</p>
-          <div className="font-mono text-white bg-gray-800 px-3 py-2 rounded-lg inline-block select-all">
+          <div className="font-mono text-white bg-midnight-800 px-3 py-2 rounded-lg inline-block select-all">
             /sync {syncCode}
           </div>
         </div>
@@ -165,13 +165,13 @@ const GameIntegrationPanel: React.FC<GameIntegrationPanelProps> = ({ user, token
       {isGameConnected && (
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
-            <div className="bg-gray-750 rounded-lg p-3 text-center">
+            <div className="bg-midnight-700 rounded-lg p-3 text-center">
               <Zap className="h-6 w-6 text-yellow-400 mx-auto mb-2" />
               <p className="text-white font-semibold">Real-time Sync</p>
               <p className="text-xs text-gray-400">Assets sync automatically</p>
             </div>
-            <div className="bg-gray-750 rounded-lg p-3 text-center">
-              <Clock className="h-6 w-6 text-blue-400 mx-auto mb-2" />
+            <div className="bg-midnight-700 rounded-lg p-3 text-center">
+              <Clock className="h-6 w-6 text-neon-400 mx-auto mb-2" />
               <p className="text-white font-semibold">Live Transactions</p>
               <p className="text-xs text-gray-400">Instant game notifications</p>
             </div>
@@ -179,7 +179,7 @@ const GameIntegrationPanel: React.FC<GameIntegrationPanelProps> = ({ user, token
 
           {/* Game Account Info */}
           {inGameId && user && (
-            <div className="bg-gray-750 rounded-lg p-4">
+            <div className="bg-midnight-700 rounded-lg p-4">
               <h4 className="text-white font-semibold mb-2">Linked Account</h4>
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between">
@@ -195,7 +195,7 @@ const GameIntegrationPanel: React.FC<GameIntegrationPanelProps> = ({ user, token
                 <button
                   onClick={handleSync}
                   disabled={gameStatus === 'syncing'}
-                  className="bg-purple-600 hover:bg-purple-700 text-white py-2 px-4 rounded-lg font-semibold transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="bg-neon-500 hover:bg-neon-600 text-white py-2 px-4 rounded-lg font-semibold transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Sync Assets
                 </button>
@@ -214,7 +214,7 @@ const GameIntegrationPanel: React.FC<GameIntegrationPanelProps> = ({ user, token
 
       {/* Connection Instructions */}
       {!isGameConnected && (
-        <div className="bg-gray-750 rounded-lg p-4">
+        <div className="bg-midnight-700 rounded-lg p-4">
           <h4 className="text-white font-semibold mb-2">How to Connect</h4>
           <ol className="text-sm text-gray-400 space-y-1">
             <li>1. Launch your racing game</li>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,15 +16,15 @@ const Header: React.FC<HeaderProps> = ({ user, setUser }) => {
   };
 
   return (
-    <header className="bg-gray-900 border-b border-gray-800 sticky top-0 z-50 backdrop-blur-sm bg-opacity-95">
+    <header className="bg-midnight-900 border-b border-midnight-700 sticky top-0 z-50 backdrop-blur-sm bg-opacity-95">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
           <Link to="/" className="flex items-center space-x-2 group">
-            <div className="bg-gradient-to-r from-blue-500 to-purple-600 p-2 rounded-lg group-hover:scale-110 transition-transform duration-200">
+            <div className="bg-gradient-to-r from-neon-500 to-neon-400 p-2 rounded-lg group-hover:scale-110 transition-transform duration-200">
               <Zap className="h-6 w-6 text-white" />
             </div>
-            <span className="text-xl font-bold text-white">RaceVault</span>
+            <span className="text-xl font-bold text-white">Midnight+</span>
           </Link>
 
           {/* Navigation */}
@@ -32,9 +32,9 @@ const Header: React.FC<HeaderProps> = ({ user, setUser }) => {
             <Link
               to="/"
               className={`flex items-center space-x-1 px-3 py-2 rounded-lg transition-colors duration-200 ${
-                isActive('/') 
-                  ? 'text-blue-400 bg-blue-500/10' 
-                  : 'text-gray-300 hover:text-white hover:bg-gray-800'
+                isActive('/')
+                  ? 'text-neon-400 bg-neon-500/10'
+                  : 'text-gray-300 hover:text-neon-400 hover:bg-midnight-800'
               }`}
             >
               <ShoppingCart className="h-4 w-4" />
@@ -43,9 +43,9 @@ const Header: React.FC<HeaderProps> = ({ user, setUser }) => {
             <Link
               to="/dashboard"
               className={`flex items-center space-x-1 px-3 py-2 rounded-lg transition-colors duration-200 ${
-                isActive('/dashboard') 
-                  ? 'text-blue-400 bg-blue-500/10' 
-                  : 'text-gray-300 hover:text-white hover:bg-gray-800'
+                isActive('/dashboard')
+                  ? 'text-neon-400 bg-neon-500/10'
+                  : 'text-gray-300 hover:text-neon-400 hover:bg-midnight-800'
               }`}
             >
               <User className="h-4 w-4" />
@@ -54,9 +54,9 @@ const Header: React.FC<HeaderProps> = ({ user, setUser }) => {
             <Link
               to="/analytics"
               className={`flex items-center space-x-1 px-3 py-2 rounded-lg transition-colors duration-200 ${
-                isActive('/analytics') 
-                  ? 'text-blue-400 bg-blue-500/10' 
-                  : 'text-gray-300 hover:text-white hover:bg-gray-800'
+                isActive('/analytics')
+                  ? 'text-neon-400 bg-neon-500/10'
+                  : 'text-gray-300 hover:text-neon-400 hover:bg-midnight-800'
               }`}
             >
               <BarChart3 className="h-4 w-4" />

--- a/src/components/LiveTransactionFeed.tsx
+++ b/src/components/LiveTransactionFeed.tsx
@@ -64,7 +64,7 @@ const LiveTransactionFeed: React.FC<LiveTransactionFeedProps> = ({ user, onTrans
   const getTransactionIcon = (type: LiveGameTransaction['type']) => {
     switch (type) {
       case 'buy_request': return <TrendingUp className="h-4 w-4 text-green-400" />;
-      case 'sell_offer': return <TrendingDown className="h-4 w-4 text-blue-400" />;
+      case 'sell_offer': return <TrendingDown className="h-4 w-4 text-neon-400" />;
       case 'trade_request': return <ArrowRightLeft className="h-4 w-4 text-purple-400" />;
     }
   };
@@ -117,7 +117,7 @@ const LiveTransactionFeed: React.FC<LiveTransactionFeedProps> = ({ user, onTrans
     <div className="fixed bottom-4 right-4 z-50">
       {/* Notification Toast */}
       {showNotification && (
-        <div className="absolute bottom-full right-0 mb-4 bg-blue-600 text-white px-4 py-2 rounded-lg shadow-lg animate-bounce">
+        <div className="absolute bottom-full right-0 mb-4 bg-neon-500 text-white px-4 py-2 rounded-lg shadow-lg animate-bounce">
           <div className="flex items-center space-x-2">
             <Bell className="h-4 w-4" />
             <span className="text-sm font-semibold">New game transaction!</span>
@@ -126,12 +126,12 @@ const LiveTransactionFeed: React.FC<LiveTransactionFeedProps> = ({ user, onTrans
       )}
 
       {/* Feed Container */}
-      <div className={`bg-gray-800 border border-gray-700 rounded-xl shadow-2xl transition-all duration-300 ${
+      <div className={`bg-midnight-800 border border-midnight-700 rounded-xl shadow-2xl transition-all duration-300 ${
         isExpanded ? 'w-96 h-96' : 'w-80 h-16'
       }`}>
         {/* Header */}
         <div 
-          className="flex items-center justify-between p-4 cursor-pointer hover:bg-gray-750 rounded-t-xl"
+          className="flex items-center justify-between p-4 cursor-pointer hover:bg-midnight-700 rounded-t-xl"
           onClick={handleExpand}
         >
           <div className="flex items-center space-x-3">
@@ -141,7 +141,7 @@ const LiveTransactionFeed: React.FC<LiveTransactionFeedProps> = ({ user, onTrans
               ) : (
                 <WifiOff className="h-5 w-5 text-red-400" />
               )}
-              <Zap className="h-5 w-5 text-blue-400" />
+              <Zap className="h-5 w-5 text-neon-400" />
             </div>
             <div>
               <h3 className="text-white font-semibold">Live Game Feed</h3>
@@ -208,7 +208,7 @@ const LiveTransactionFeed: React.FC<LiveTransactionFeedProps> = ({ user, onTrans
                   <div className="mb-2">
                     <p className="text-white text-sm font-medium">{transaction.asset.name}</p>
                     <div className="flex items-center justify-between">
-                      <span className="text-blue-400 font-semibold">
+                      <span className="text-neon-400 font-semibold">
                         {formatPrice(transaction.requestedPrice, tokenSymbol)}
                       </span>
                       {transaction.currentPrice && transaction.currentPrice !== transaction.requestedPrice && (
@@ -230,7 +230,7 @@ const LiveTransactionFeed: React.FC<LiveTransactionFeedProps> = ({ user, onTrans
                       <button
                         onClick={() => handleAccept(transaction)}
                         disabled={tokenBalance < transaction.requestedPrice || isProcessingTransaction}
-                        className="flex-1 bg-green-600 hover:bg-green-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-xs py-2 px-3 rounded-lg transition-colors duration-200 flex items-center justify-center space-x-1"
+                        className="flex-1 bg-green-600 hover:bg-green-700 disabled:bg-midnight-600 disabled:cursor-not-allowed text-white text-xs py-2 px-3 rounded-lg transition-colors duration-200 flex items-center justify-center space-x-1"
                       >
                         <CheckCircle className="h-3 w-3" />
                         <span>{isProcessingTransaction ? 'Processing...' : 'Buy'}</span>
@@ -238,7 +238,7 @@ const LiveTransactionFeed: React.FC<LiveTransactionFeedProps> = ({ user, onTrans
                       <button
                         onClick={() => handleDecline(transaction)}
                         disabled={isProcessingTransaction}
-                        className="flex-1 bg-red-600 hover:bg-red-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-xs py-2 px-3 rounded-lg transition-colors duration-200 flex items-center justify-center space-x-1"
+                        className="flex-1 bg-red-600 hover:bg-red-700 disabled:bg-midnight-600 disabled:cursor-not-allowed text-white text-xs py-2 px-3 rounded-lg transition-colors duration-200 flex items-center justify-center space-x-1"
                       >
                         <XCircle className="h-3 w-3" />
                         <span>{isProcessingTransaction ? 'Processing...' : 'Decline'}</span>

--- a/src/components/Marketplace.tsx
+++ b/src/components/Marketplace.tsx
@@ -93,7 +93,7 @@ const Marketplace: React.FC<MarketplaceProps> = ({ user, setUser }) => {
         try {
           const apiUrl =
             import.meta.env.VITE_APP_API_URL ||
-            "https://racevault.onrender.com";
+            "https://midnightplus.example";
           const response = await fetch(`${apiUrl}/api/purchase-vehicle`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -161,12 +161,12 @@ const Marketplace: React.FC<MarketplaceProps> = ({ user, setUser }) => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-900">
+    <div className="min-h-screen bg-midnight-900">
       {/* Hero Section */}
-      <div className="bg-gradient-to-r from-blue-900 via-purple-900 to-pink-900 py-16">
+      <div className="bg-gradient-to-r from-midnight-900 via-midnight-800 to-midnight-700 py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h1 className="text-4xl md:text-6xl font-bold text-white mb-4">
-            RaceVault <span className="text-blue-400">Marketplace</span>
+            Midnight+ <span className="text-neon-400">Marketplace</span>
           </h1>
           <p className="text-xl text-gray-300 mb-8">
             Discover, collect, and trade the most exclusive racing NFTs
@@ -179,13 +179,13 @@ const Marketplace: React.FC<MarketplaceProps> = ({ user, setUser }) => {
               placeholder="Search cars, modifications, and properties..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-12 pr-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-blue-500"
+              className="w-full pl-12 pr-4 py-3 bg-midnight-800 border border-midnight-700 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-neon-500"
             />
           </div>
         </div>
       </div>
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Filters */}
         <div className="flex flex-wrap gap-4 mb-8">
           {/* Category Filter */}
@@ -198,8 +198,8 @@ const Marketplace: React.FC<MarketplaceProps> = ({ user, setUser }) => {
                   onClick={() => setSelectedCategory(category.id)}
                   className={`flex items-center space-x-2 px-4 py-2 rounded-lg transition-colors duration-200 ${
                     selectedCategory === category.id
-                      ? "bg-blue-600 text-white"
-                      : "bg-gray-800 text-gray-300 hover:bg-gray-700"
+                      ? "bg-neon-500 text-white"
+                      : "bg-midnight-800 text-gray-300 hover:bg-midnight-700"
                   }`}
                 >
                   <Icon className="h-4 w-4" />
@@ -213,7 +213,7 @@ const Marketplace: React.FC<MarketplaceProps> = ({ user, setUser }) => {
           <select
             value={selectedRarity}
             onChange={(e) => setSelectedRarity(e.target.value)}
-            className="bg-gray-800 border border-gray-700 text-white rounded-lg px-4 py-2 focus:outline-none focus:border-blue-500"
+            className="bg-midnight-800 border border-midnight-700 text-white rounded-lg px-4 py-2 focus:outline-none focus:border-neon-500"
           >
             {rarities.map((rarity) => (
               <option key={rarity} value={rarity}>

--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -102,7 +102,7 @@ const WalletConnect: React.FC<WalletConnectProps> = ({ user, setUser }) => {
           <div className="text-sm text-gray-300">
             {formatAddress(user.address)}
           </div>
-          <div className="text-xs text-blue-400">{user.balance} ETH</div>
+          <div className="text-xs text-neon-400">{user.balance} ETH</div>
           <div className="text-gray-400 text-xs">
             {formatNumber(tokenBalance)} {tokenSymbol}
           </div>
@@ -121,7 +121,7 @@ const WalletConnect: React.FC<WalletConnectProps> = ({ user, setUser }) => {
   return (
     <button
       onClick={handleConnect}
-      className="flex items-center space-x-2 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white px-6 py-2 rounded-lg transition-all duration-200 transform hover:scale-105"
+      className="flex items-center space-x-2 bg-gradient-to-r from-neon-500 to-neon-400 hover:from-neon-600 hover:to-neon-500 text-white px-6 py-2 rounded-lg transition-all duration-200 transform hover:scale-105"
     >
       <Wallet className="h-4 w-4" />
       <span>Connect Wallet</span>

--- a/src/context/GameIntegrationContext.tsx
+++ b/src/context/GameIntegrationContext.tsx
@@ -84,7 +84,7 @@ export const GameIntegrationProvider = ({
     }));
 
     const apiUrl =
-      import.meta.env.VITE_APP_API_URL || "https://racevault.onrender.com";
+      import.meta.env.VITE_APP_API_URL || "https://midnightplus.example";
 
     try {
       // Fetch the user's actual token balance

--- a/src/hooks/useLiveTransactions.ts
+++ b/src/hooks/useLiveTransactions.ts
@@ -10,7 +10,7 @@ export const useLiveTransactions = () => {
   // Simulate WebSocket connection
   useEffect(() => {
     const apiUrl =
-      import.meta.env.VITE_APP_API_URL || "https://racevault.onrender.com";
+      import.meta.env.VITE_APP_API_URL || "https://midnightplus.example";
     const eventSource = new EventSource(`${apiUrl}/events`);
 
     eventSource.onopen = () => {
@@ -111,7 +111,7 @@ export const useLiveTransactions = () => {
   }, []);
 
   const declineTransaction = useCallback(async (transaction: LiveGameTransaction) => {
-    const apiUrl = import.meta.env.VITE_APP_API_URL || "https://racevault.onrender.com";
+    const apiUrl = import.meta.env.VITE_APP_API_URL || "https://midnightplus.example";
     try {
       const response = await fetch(`${apiUrl}/api/reject-purchase`, {
         method: "POST",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,20 @@
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        midnight: {
+          700: '#1e293b',
+          800: '#1a2234',
+          900: '#0f172a',
+        },
+        neon: {
+          400: '#38bdf8',
+          500: '#0ea5e9',
+          600: '#0284c7',
+        },
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- Rename UI branding to Midnight+
- Add midnight color palette and neon accents across components
- Update default API endpoints and favicon

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a93b9df90c83318fd014bc1258d350